### PR TITLE
Fix fib lint errors

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n: number): number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
Fixed lint error in fib.ts by typing n in the fibonacci function to number and setting its return type to number instead of any.